### PR TITLE
PR - Mapeando as classes utilizando @Entity, mesmo em classes mãe

### DIFF
--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/Funcionario.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/Funcionario.java
@@ -1,6 +1,14 @@
 package ifsuldeminas.bcc.teii.trabalho.estoque.model.entity;
 
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
 public class Funcionario {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
     private String nome;
     private String nomeUsuario;
@@ -12,6 +20,10 @@ public class Funcionario {
         this.nomeUsuario = nomeUsuario;
         this.senha = senha;
         this.tipo = tipo;
+    }
+
+    public Funcionario() {
+
     }
 
     public void AddFuncionario(){

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/colaboradores/Cliente.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/colaboradores/Cliente.java
@@ -12,7 +12,7 @@ import javax.persistence.Id;
  *
  * @author matheus
  */
-
+@Entity
 public class Cliente extends Colaboradores{
     private String cnpj;
 
@@ -20,7 +20,11 @@ public class Cliente extends Colaboradores{
         super(nome, telefone, endereco);
         this.cnpj = cnpj;
     }
-    
+
+    public Cliente() {
+
+    }
+
     public void EditarColaboradores(String nome, String telefone, String endereco) {
         
         this.cnpj = cnpj;

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/colaboradores/Colaboradores.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/colaboradores/Colaboradores.java
@@ -5,11 +5,16 @@
  */
 package ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.colaboradores;
 
+import javax.persistence.*;
+
 /**
  *
  * @author matheus
  */
+
 public class Colaboradores {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
     private String nome;
     private String telefone;
@@ -19,6 +24,10 @@ public class Colaboradores {
         this.nome = nome;
         this.telefone = telefone;
         this.endereco = endereco;
+    }
+
+    public Colaboradores() {
+
     }
 
     public void EditarColaboradores(int id) {

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/colaboradores/Colaboradores.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/colaboradores/Colaboradores.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
  *
  * @author matheus
  */
-
+@Entity
 public class Colaboradores {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/colaboradores/Fornecedor.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/colaboradores/Fornecedor.java
@@ -6,13 +6,19 @@
 package ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.colaboradores;
 
 import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.comercial.Produto;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
 import java.util.ArrayList;
 
 /**
  *
  * @author matheus
  */
+@Entity
 public class Fornecedor extends Colaboradores{
+    @Id
     private String cpf;
     private ArrayList<Produto> produtos;
 
@@ -20,6 +26,10 @@ public class Fornecedor extends Colaboradores{
         super(nome, telefone, endereco);
         this.cpf = cpf;
         this.produtos = produtos;
+    }
+
+    public Fornecedor() {
+
     }
 
     public String getCpf() {

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Compra.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Compra.java
@@ -3,14 +3,20 @@ package ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.comercial;
 import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.colaboradores.Colaboradores;
 import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.colaboradores.Fornecedor;
 
+import javax.persistence.Entity;
 import java.util.ArrayList;
 
+@Entity
 public class Compra extends Transacao{
     private Fornecedor Fornecedor;
 
-    public Compra(String data, double total, ArrayList<Produto> Produtos, Colaboradores Colaboradores, Fornecedor fornecedor) {
-        super(data, total, Produtos, Colaboradores);
+    public Compra(String data, double total, ArrayList<Produto> Produtos, Fornecedor fornecedor) {
+        super(data, total, Produtos);
         Fornecedor = fornecedor;
+    }
+
+    public Compra() {
+        super();
     }
 
     public Fornecedor getFornecedor(){return Fornecedor;}

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/NotaFiscal.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/NotaFiscal.java
@@ -1,30 +1,32 @@
 package ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.comercial;
 
 import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.Funcionario;
+import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.colaboradores.Cliente;
 import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.colaboradores.Colaboradores;
 
+import javax.persistence.*;
 import java.util.Date;
 
+@Entity
 public class NotaFiscal {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
-    private Colaboradores Colaborador;
+    @Temporal(TemporalType.DATE)
     private Date data;
+    private Cliente cliente;
     private Funcionario funcionario;
     private Transacao transacao;
 
-    public NotaFiscal(Colaboradores colaborador, Date data, Funcionario funcionario, Transacao transacao) {
-        Colaborador = colaborador;
+    public NotaFiscal(Date data, Cliente cliente, Funcionario funcionario, Transacao transacao) {
         this.data = data;
+        this.cliente = cliente;
         this.funcionario = funcionario;
         this.transacao = transacao;
     }
 
-    public Colaboradores getColaborador() {
-        return Colaborador;
-    }
+    public NotaFiscal() {
 
-    public void setColaborador(Colaboradores colaborador) {
-        Colaborador = colaborador;
     }
 
     public Date getData() {

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Produto.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Produto.java
@@ -5,13 +5,20 @@
  */
 package ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.comercial;
 
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
 /**
  *
  * @author matheus
  */
 
+@Entity
 public class Produto {
-    
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
     private String nome;
     private int quantidade;

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Produto.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Produto.java
@@ -30,6 +30,10 @@ public class Produto {
         this.especificacao = especificacao;
     }
 
+    public Produto() {
+
+    }
+
     public void EditarProduto(int id) {
         //getId(id)
     }

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Transacao.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Transacao.java
@@ -3,20 +3,23 @@ package ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.comercial;
 import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.colaboradores.Colaboradores;
 import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.comercial.Produto;
 
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import java.util.ArrayList;
 
 public class Transacao {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
     private String data;
     private double total;
     private ArrayList<Produto> Produtos;
-    private Colaboradores Colaboradores;
 
-    public Transacao (String data, double total, ArrayList<Produto> Produtos, Colaboradores Colaboradores){
+    public Transacao (String data, double total, ArrayList<Produto> Produtos){
         this.data = data;
         this.total = total;
         this.Produtos = Produtos;
-        this.Colaboradores = Colaboradores;
     }
 
     /*
@@ -38,7 +41,5 @@ public class Transacao {
     public ArrayList<Produto> getProdutos(){return Produtos;}
     public void setProdutos(ArrayList<Produto> produtos){this.Produtos = produtos;}
 
-    public Colaboradores getColaboradores(){return Colaboradores;}
-    public void setColaboradores(Colaboradores colaboradores){this.Colaboradores = colaboradores;}
 }
 

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Transacao.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Transacao.java
@@ -3,11 +3,13 @@ package ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.comercial;
 import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.colaboradores.Colaboradores;
 import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.comercial.Produto;
 
+import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import java.util.ArrayList;
 
+@Entity
 public class Transacao {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -20,6 +22,10 @@ public class Transacao {
         this.data = data;
         this.total = total;
         this.Produtos = Produtos;
+    }
+
+    public Transacao (){
+
     }
 
     /*

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Venda.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Venda.java
@@ -15,6 +15,10 @@ public class Venda extends Transacao{
         Cliente = cliente;
     }
 
+    public Venda() {
+        super();
+    }
+
     public Cliente getCliente() {return Cliente;}
     public void setCliente(Cliente Cliente){this.Cliente=Cliente;}
 }

--- a/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Venda.java
+++ b/src/main/java/ifsuldeminas/bcc/teii/trabalho/estoque/model/entity/comercial/Venda.java
@@ -3,13 +3,15 @@ package ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.comercial;
 import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.colaboradores.Cliente;
 import ifsuldeminas.bcc.teii.trabalho.estoque.model.entity.colaboradores.Colaboradores;
 
+import javax.persistence.Entity;
 import java.util.ArrayList;
 
+@Entity
 public class Venda extends Transacao{
     private Cliente Cliente;
 
-    public Venda(String data, double total, ArrayList<Produto> Produtos, Colaboradores Colaboradores, Cliente cliente) {
-        super(data, total, Produtos, Colaboradores);
+    public Venda(String data, double total, ArrayList<Produto> Produtos, Cliente cliente) {
+        super(data, total, Produtos);
         Cliente = cliente;
     }
 


### PR DESCRIPTION
Classes filhas como, Compras e Vendas, que herdam de Transação e Cliente e Fornecedor, que herdam de Colaboradores, apresentavam erros por não possuírem ID, a correção foi inserir o @Entity também nas classes mãe, como mostradas no _commit_ de mapeamento do exemplo passado em aula.